### PR TITLE
Bug 331 - One Time products not updating subscriptions

### DIFF
--- a/src/Commands/GetOneTimeProductSubscriptionIssues.php
+++ b/src/Commands/GetOneTimeProductSubscriptionIssues.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Railroad\Ecommerce\Commands;
+
+use DateTime;
+use Illuminate\Console\Command;
+use Illuminate\Database\DatabaseManager;
+use Carbon\Carbon;
+use Railroad\Ecommerce\Events\OrderEvent;
+use Railroad\Ecommerce\Listeners\OrderOneTimeProductListener;
+use Railroad\Ecommerce\Managers\EcommerceEntityManager;
+use Railroad\Ecommerce\Repositories\OrderRepository;
+use Railroad\Ecommerce\Repositories\SubscriptionRepository;
+use Railroad\Ecommerce\Services\DateTimeService;
+use Railroad\Ecommerce\Services\UserProductService;
+
+class GetOneTimeProductSubscriptionIssues extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'GetOneTimeProductSubscriptionIssues';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Returns a list of subscriptions that are renewing 6 or more days before one time product brand access expires';
+
+    /**
+     * @var DatabaseManager
+     */
+    private $databaseManager;
+    /**
+     * @var SubscriptionRepository
+     */
+    protected $subscriptionRepository;
+    /**
+     * @var EcommerceEntityManager
+     */
+    private $ecommerceEntityManager;
+    /**
+     * @var UserProductService
+     */
+    protected $userProductService;
+    /**
+     * @var DateTimeService
+     */
+    protected $dateTimeService;
+    /**
+     * @var OrderRepository
+     */
+    protected $orderRepository;
+
+    /**
+     * @param DatabaseManager $databaseManager
+     * @param SubscriptionRepository $subscriptionRepository
+     * @param EcommerceEntityManager $ecommerceEntityManager
+     * @param UserProductService $userProductService
+     * @param DateTimeService $dateTimeService
+     * @param OrderRepository $orderRepository
+     *
+     */
+    public function __construct(
+        DatabaseManager        $databaseManager,
+        SubscriptionRepository $subscriptionRepository,
+        EcommerceEntityManager $ecommerceEntityManager,
+        UserProductService     $userProductService,
+        DateTimeService        $dateTimeService,
+        OrderRepository        $orderRepository
+    )
+    {
+        parent::__construct();
+
+        $this->databaseManager = $databaseManager;
+        $this->subscriptionRepository = $subscriptionRepository;
+        $this->ecommerceEntityManager = $ecommerceEntityManager;
+        $this->userProductService = $userProductService;
+        $this->dateTimeService = $dateTimeService;
+        $this->orderRepository = $orderRepository;
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $flaggedSubscriptions = collect($this->databaseManager->connection('musora_mysql')
+            ->select("SELECT s.id, s.user_id, u.email, s.brand, s.start_date, s.paid_until, latest_expiration_date.access_until, latest_expiration_date.name, latest_expiration_date.product_id, o2.id as order_id
+                            FROM ecommerce_subscriptions s
+                            INNER JOIN usora_users u on u.id = s.user_id
+                            INNER JOIN (SELECT up.user_id, p.brand, p.name, up.product_id, max(expiration_date) as access_until FROM ecommerce_user_products up
+                                INNER JOIN ecommerce_products p on p.id = up.product_id
+                                where expiration_date is not null and expiration_date >= CURRENT_TIME and digital_access_time_type = 'one time'
+                                group by up.user_id, p.brand
+                                order by up.user_id DESC) latest_expiration_date on latest_expiration_date.user_id = s.user_id and latest_expiration_date.brand = s.brand
+                            INNER JOIN (SELECT oi.product_id, o.id, o.user_id from ecommerce_orders o 
+                                       INNER JOIN  ecommerce_order_items oi on oi.order_id = o.id) o2 on o2.product_id = latest_expiration_date.product_id and o2.user_id = s.user_id
+                            where s.is_active and s.paid_until >= CURRENT_TIME and s.canceled_on is null and latest_expiration_date.access_until > DATE_ADD(s.paid_until, INTERVAL 6 DAY) and s.type <> 'payment plan'
+                            order by s.paid_until"));
+        $this->info($this->description);
+        $this->table(['User ID', 'Email', 'Brand', 'Product Name', 'Subscription Paid Until', 'Product Access Until', 'Diff Days'], $flaggedSubscriptions->map(function ($row) {
+            $diffDays = (new DateTime($row->access_until))->diff(new DateTime($row->paid_until))->format('%a');
+            return collect([$row->user_id, $row->email, $row->brand, $row->name, $row->paid_until, $row->access_until, $diffDays]);
+        }));
+        $this->info("{$flaggedSubscriptions->count()} records found");
+
+
+        if ($this->confirm('Attempt to resolve issues automatically?')) {
+            $listener = new OrderOneTimeProductListener($this->subscriptionRepository,
+                $this->ecommerceEntityManager,
+                $this->userProductService,
+                $this->dateTimeService);
+
+            $i = 1;
+            foreach ($flaggedSubscriptions as $flaggedSubscription){
+                $orderId = $flaggedSubscription->order_id;
+                $this->info("<fg=white>{i}/{$flaggedSubscriptions->count()}</>");
+
+                $order = $this->orderRepository->find($orderId);
+                $listener->handle(new OrderEvent($order, null));
+
+                $subscriptionID = $flaggedSubscription->id;
+                $updates = collect($this->databaseManager->connection('musora_mysql')
+                    ->select("SELECT s.id, s.paid_until, up.expiration_date
+                            FROM ecommerce_subscriptions s
+                            INNER JOIN ecommerce_products p on s.product_id = p.id
+                            INNER JOIN ecommerce_user_products up on up.product_id = p.id and up.user_id = s.user_id
+                            WHERE s.id = {$subscriptionID}
+                            "))->first();
+
+                $this->info("\nUser: {$flaggedSubscription->user_id}\nOne Time Product: {$flaggedSubscription->name}");
+                $this->info("Subscription paid_until <fg=white>{$flaggedSubscription->paid_until}</> to <fg=white>{$updates->paid_until}</>");
+                $this->info("Subscription expiration_date <fg=white>{$flaggedSubscription->access_until}</> to <fg=white>{$updates->expiration_date}</>");
+                $i++;
+            };
+        }
+    }
+}

--- a/src/Listeners/OrderOneTimeProductListener.php
+++ b/src/Listeners/OrderOneTimeProductListener.php
@@ -6,6 +6,7 @@ use Carbon\Carbon;
 use Doctrine\ORM\NonUniqueResultException;
 use Faker\Provider\DateTime;
 use Railroad\Ecommerce\Entities\Product;
+use Railroad\Ecommerce\Entities\Subscription;
 use Railroad\Ecommerce\Events\OrderEvent;
 use Railroad\Ecommerce\Events\Subscriptions\SubscriptionUpdated;
 use Railroad\Ecommerce\Managers\EcommerceEntityManager;
@@ -70,7 +71,10 @@ class OrderOneTimeProductListener
         $subscriptions = collect(
             $this->subscriptionRepository->getActiveSubscriptionsByUserId($order->getUser()->getId())
         );
-        $subscriptionsMap = $subscriptions->mapWithKeys(function ($subscription, $key) {
+        $subscriptionsMap = $subscriptions->sortBy(function (Subscription $subscription) {
+            //mapWithKeys takes the last value for duplicate keys which is why we sort by ascending here
+            return $subscription->getPaidUntil();
+        })->mapWithKeys(function ($subscription, $key) {
             return [$subscription->getBrand() => $subscription];
         });
 

--- a/src/Listeners/OrderOneTimeProductListener.php
+++ b/src/Listeners/OrderOneTimeProductListener.php
@@ -103,5 +103,6 @@ class OrderOneTimeProductListener
         $this->ecommerceEntityManager->persist($subscription);
         $this->ecommerceEntityManager->flush($subscription);
         event(new SubscriptionUpdated($oldSubscription, $subscription));
+        $this->userProductService->updateSubscriptionProducts($subscription);
     }
 }

--- a/src/Listeners/OrderOneTimeProductListener.php
+++ b/src/Listeners/OrderOneTimeProductListener.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Railroad\Ecommerce\Listeners;
+
+use Carbon\Carbon;
+use Doctrine\ORM\NonUniqueResultException;
+use Faker\Provider\DateTime;
+use Railroad\Ecommerce\Entities\Product;
+use Railroad\Ecommerce\Events\OrderEvent;
+use Railroad\Ecommerce\Events\Subscriptions\SubscriptionUpdated;
+use Railroad\Ecommerce\Managers\EcommerceEntityManager;
+use Railroad\Ecommerce\Repositories\SubscriptionRepository;
+use Railroad\Ecommerce\Repositories\UserProductRepository;
+use Railroad\Ecommerce\Services\DateTimeService;
+use Railroad\Ecommerce\Services\UserProductService;
+use Throwable;
+use function Aws\map;
+
+class OrderOneTimeProductListener
+{
+    /**
+     * @var SubscriptionRepository
+     */
+    protected $subscriptionRepository;
+    /**
+     * @var EcommerceEntityManager
+     */
+    private $ecommerceEntityManager;
+    /**
+     * @var UserProductService
+     */
+    protected $userProductService;
+    /**
+     * @var DateTimeService
+     */
+    protected $dateTimeService;
+
+    /**
+     * @param SubscriptionRepository $subscriptionRepository
+     * @param EcommerceEntityManager $ecommerceEntityManager
+     * @param UserProductService $userProductService
+     * @param DateTimeService $dateTimeService
+     */
+    public function __construct(
+        SubscriptionRepository $subscriptionRepository,
+        EcommerceEntityManager $ecommerceEntityManager,
+        UserProductService     $userProductService,
+        DateTimeService        $dateTimeService
+    )
+    {
+        $this->subscriptionRepository = $subscriptionRepository;
+        $this->ecommerceEntityManager = $ecommerceEntityManager;
+        $this->userProductService = $userProductService;
+        $this->dateTimeService = $dateTimeService;
+    }
+
+    /**
+     * @param OrderEvent $event
+     *
+     * @throws NonUniqueResultException
+     * @throws Throwable
+     */
+    public function handle(OrderEvent $event)
+    {
+        $order = $event->getOrder();
+        if (!$order->getUser() || !$order->getOrderItems() || !count($order->getOrderItems())) return;
+        $orderItems = $order->getOrderItems();
+        $subscriptions = collect($this->subscriptionRepository->getActiveSubscriptionsByUserId($order->getUser()->getId()));
+        $subscriptionsMap = $subscriptions->mapWithKeys(function ($subscription, $key) {
+            return [$subscription->getBrand() => $subscription];
+        });
+
+        foreach ($orderItems as $orderItem) {
+            $product = $orderItem->getProduct();
+            $subscription = $subscriptionsMap[$product->getBrand()] ?? null;
+            if ($subscription == null) continue;
+            $paidUntil = $subscription->getPaidUntil()->copy();
+            $isOneTimeProduct = $product->getType() == Product::TYPE_DIGITAL_ONE_TIME &&
+                !empty($product->getSubscriptionIntervalType()) &&
+                !empty($product->getSubscriptionIntervalCount());
+
+            if ($isOneTimeProduct) {
+                $intervalType = $product->getSubscriptionIntervalType();
+                $nIntervals = $product->getSubscriptionIntervalCount() * $orderItem->getQuantity();
+                $paidUntil = $this->dateTimeService->addInterval($paidUntil, $intervalType, $nIntervals);
+
+                $this->updateSubscription($subscription, $paidUntil);
+            }
+        }
+    }
+
+    /**
+     * @param $subscription
+     * @param Carbon $paidUntil
+     * @return void
+     * @throws \Doctrine\ORM\ORMException
+     * @throws \Doctrine\ORM\OptimisticLockException
+     */
+    public function updateSubscription($subscription, Carbon $paidUntil)
+    {
+        $oldSubscription = clone $subscription;
+        $subscription->setPaidUntil($paidUntil);
+        $this->ecommerceEntityManager->persist($subscription);
+        $this->ecommerceEntityManager->flush($subscription);
+        event(new SubscriptionUpdated($oldSubscription, $subscription));
+    }
+}

--- a/src/Listeners/OrderUserProductListener.php
+++ b/src/Listeners/OrderUserProductListener.php
@@ -79,7 +79,7 @@ class OrderUserProductListener
                     !empty($product->getSubscriptionIntervalType()) &&
                     !empty($product->getSubscriptionIntervalCount())) {
                     $userProduct = $this->userProductService->getUserProduct($order->getUser(), $product);
-                    $start = $userProduct->getExpirationDate()->copy() ?? Carbon::now();
+                    $start = ($userProduct ? $userProduct->getExpirationDate()->copy() : null) ?? Carbon::now();
                     $intervalType = $product->getSubscriptionIntervalType();
                     $nIntervals = $product->getSubscriptionIntervalCount() * $orderItem->getQuantity();
 

--- a/src/Providers/EcommerceServiceProvider.php
+++ b/src/Providers/EcommerceServiceProvider.php
@@ -50,6 +50,7 @@ use Railroad\Ecommerce\Listeners\DuplicateSubscriptionHandler;
 use Railroad\Ecommerce\Listeners\GiveContentAccessListener;
 use Railroad\Ecommerce\Listeners\MobileOrderUserProductListener;
 use Railroad\Ecommerce\Listeners\OrderInvoiceListener;
+use Railroad\Ecommerce\Listeners\OrderOneTimeProductListener;
 use Railroad\Ecommerce\Listeners\OrderShippingFulfilmentListener;
 use Railroad\Ecommerce\Listeners\OrderUserProductListener;
 use Railroad\Ecommerce\Listeners\SubscriptionInvoiceListener;
@@ -76,6 +77,7 @@ class EcommerceServiceProvider extends ServiceProvider
                 OrderUserProductListener::class,
                 OrderInvoiceListener::class,
                 DuplicateSubscriptionHandler::class,
+                OrderOneTimeProductListener::class
             ],
             SubscriptionRenewed::class => [SubscriptionInvoiceListener::class],
             MobileOrderEvent::class => [MobileOrderUserProductListener::class]

--- a/src/Providers/EcommerceServiceProvider.php
+++ b/src/Providers/EcommerceServiceProvider.php
@@ -27,6 +27,7 @@ use Railroad\Ecommerce\Commands\FillPaymentGatewayColumnFromPaymentMethod;
 use Railroad\Ecommerce\Commands\FindDuplicateSubscriptionsAndLifetimesWithSubscriptions;
 use Railroad\Ecommerce\Commands\FixSerializeErrorInAppPurchaseTables;
 use Railroad\Ecommerce\Commands\FixSubscriptionTotalAndTaxes;
+use Railroad\Ecommerce\Commands\GetOneTimeProductSubscriptionIssues;
 use Railroad\Ecommerce\Commands\ListDueSubscriptions;
 use Railroad\Ecommerce\Commands\MatchOrderItemDiscountAmountToTotal;
 use Railroad\Ecommerce\Commands\MembershipsReportingTool;
@@ -149,7 +150,8 @@ class EcommerceServiceProvider extends ServiceProvider
                 VerifyLocalPriceConversion::class,
                 UpdateLastDigits::class,
                 MatchOrderItemDiscountAmountToTotal::class,
-                PopulatePermissionNamesColumnInEcommerceProducts::class
+                PopulatePermissionNamesColumnInEcommerceProducts::class,
+                GetOneTimeProductSubscriptionIssues::class
             ]
         );
 

--- a/src/Repositories/SubscriptionRepository.php
+++ b/src/Repositories/SubscriptionRepository.php
@@ -908,4 +908,59 @@ class SubscriptionRepository extends RepositoryBase
             ->getQuery()
             ->getResult();
     }
+
+    /**
+     * @param int $userId
+     *
+     * @return Subscription[]
+     */
+    public function getActiveSubscriptionsByUserId(int $userId): array
+    {
+        $qb = $this->createQueryBuilder('s');
+
+        $qb->andWhere(
+                $qb->expr()
+                    ->in('s.type', ':types')
+            )
+            ->andWhere(
+                $qb->expr()
+                    ->eq('s.stopped', ':not')
+            )
+            ->andWhere(
+                $qb->expr()
+                    ->eq('s.isActive', ':true')
+            )
+            ->andWhere(
+                $qb->expr()
+                    ->gt('s.paidUntil', ':now')
+            )
+            ->andWhere(
+                $qb->expr()
+                    ->isNull('s.canceledOn')
+            )
+            ->andWhere(
+                $qb->expr()
+                    ->eq('s.user', ':userId')
+            )
+            ->setParameter(
+                'now',
+                Carbon::now()
+                    ->toDateTimeString()
+            )
+            ->setParameter('not', false)
+            ->setParameter(
+                'types',
+                [
+                    Subscription::TYPE_SUBSCRIPTION,
+                    Subscription::TYPE_APPLE_SUBSCRIPTION,
+                    Subscription::TYPE_GOOGLE_SUBSCRIPTION,
+                    Subscription::TYPE_PAYPAL_SUBSCRIPTION,
+                ]
+            )
+            ->setParameter('userId', $userId)
+            ->setParameter('true', true);
+
+        return $qb->getQuery()
+            ->getResult();
+    }
 }

--- a/src/Services/DateTimeService.php
+++ b/src/Services/DateTimeService.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Railroad\Ecommerce\Services;
+
+use Carbon\Carbon;
+use \Exception;
+
+/**
+ * Class DateTimeService
+ * @package Railroad\Ecommerce\Services
+ */
+class DateTimeService
+{
+
+    /**
+     * DateTimeService constructor.
+     *
+     */
+    public function __construct()
+    {
+    }
+
+    /**
+     * @param Carbon $dateTime
+     * @param $intervalType
+     * @param int $nIntervals
+     * @return mixed
+     */
+    public function addInterval(Carbon $dateTime, $intervalType, int $nIntervals = 1)
+    {
+        switch ($intervalType) {
+            case config('ecommerce.interval_type_monthly'):
+                return $dateTime->addMonths($nIntervals);
+            case config('ecommerce.interval_type_yearly'):
+                return $dateTime->addYears($nIntervals);
+            case config('ecommerce.interval_type_daily'):
+                return $dateTime->addDays($nIntervals);
+            default:
+                throw new Exception("intervalType '$intervalType' not handled.");
+        }
+    }
+
+
+}

--- a/src/Services/UserProductService.php
+++ b/src/Services/UserProductService.php
@@ -47,8 +47,7 @@ class UserProductService
     public function __construct(
         EcommerceEntityManager $entityManager,
         UserProductRepository $userProductRepository
-    )
-    {
+    ) {
         $this->entityManager = $entityManager;
         $this->userProductRepository = $userProductRepository;
 
@@ -71,7 +70,6 @@ class UserProductService
             if ($userProduct->getProduct()
                     ->getId() == $productId &&
                 ($userProduct->isValid())) {
-
                 return true;
             }
         }
@@ -98,7 +96,6 @@ class UserProductService
                     $productIds
                 ) &&
                 ($userProduct->isValid())) {
-
                 return true;
             }
         }
@@ -119,10 +116,8 @@ class UserProductService
         $userProducts = $this->getAllUsersProducts($userId);
 
         foreach ($userProducts as $userProduct) {
-
             if ($userProduct->getProduct()
                     ->getId() == $productId) {
-
                 if ($userProduct->getExpirationDate() == null) {
                     return null;
                 }
@@ -192,9 +187,7 @@ class UserProductService
     public function getUserProduct(
         User $user,
         Product $product
-    ): ?UserProduct
-    {
-
+    ): ?UserProduct {
         /** @var $qb QueryBuilder */
         $qb = $this->userProductRepository->createQueryBuilder('up');
 
@@ -210,7 +203,7 @@ class UserProductService
             ->setParameter('product', $product);
 
         return $qb->getQuery()
-            ->getResult()[0] ?? null;
+                ->getResult()[0] ?? null;
     }
 
     /**
@@ -224,8 +217,7 @@ class UserProductService
     public function getUserProducts(
         User $user,
         $products
-    ): array
-    {
+    ): array {
         /** @var $qb QueryBuilder */
         $qb = $this->userProductRepository->createQueryBuilder('up');
 
@@ -273,9 +265,7 @@ class UserProductService
         Product $product,
         ?DateTimeInterface $expirationDate,
         $quantity
-    ): UserProduct
-    {
-
+    ): UserProduct {
         $userProduct = new UserProduct();
 
         $userProduct->setUser($user);
@@ -306,8 +296,7 @@ class UserProductService
         UserProduct $userProduct,
         ?DateTimeInterface $expirationDate,
         $quantity
-    )
-    {
+    ) {
         $oldUserProduct = clone($userProduct);
 
         $userProduct->setExpirationDate($expirationDate);
@@ -352,8 +341,7 @@ class UserProductService
         Product $product,
         ?DateTimeInterface $expirationDate,
         $quantity = 0
-    )
-    {
+    ) {
         /**
          * @var $userProduct UserProduct
          */
@@ -362,8 +350,7 @@ class UserProductService
         if (!$userProduct) {
             $productQuantity = ($quantity == 0) ? 1 : $quantity;
             $this->createUserProduct($user, $product, $expirationDate, $productQuantity);
-        }
-        else {
+        } else {
             $this->updateUserProduct($userProduct, $expirationDate, ($userProduct->getQuantity() + $quantity));
         }
     }
@@ -383,8 +370,7 @@ class UserProductService
     public function removeUserProducts(
         User $user,
         $products
-    )
-    {
+    ) {
         $userProducts = $this->getUserProducts(
             $user,
             $products->pluck('product')
@@ -392,7 +378,6 @@ class UserProductService
         );
 
         foreach ($products as $productData) {
-
             /**
              * @var $product Product
              */
@@ -410,9 +395,7 @@ class UserProductService
                 $this->entityManager->remove($userProduct);
 
                 event(new UserProductDeleted($userProduct));
-            }
-            else {
-
+            } else {
                 $quantity = $userProduct->getQuantity() - $productData['quantity'];
 
                 $userProduct->setQuantity($quantity);
@@ -436,7 +419,6 @@ class UserProductService
     public function getSubscriptionProducts(Subscription $subscription)
     {
         if ($subscription->getType() == config('ecommerce.type_payment_plan')) {
-
             if (!$subscription->getOrder()) {
                 return collect([]);
             }
@@ -453,10 +435,7 @@ class UserProductService
                     ];
                 }
             );
-
-        }
-        else {
-
+        } else {
             return collect(
                 [
                     [
@@ -482,7 +461,6 @@ class UserProductService
         // we only want to update the expiration date of non-payment plan subscription products
         if ($subscription->getType() != Subscription::TYPE_PAYMENT_PLAN) {
             foreach ($products as $productData) {
-
                 /** @var $paidUntil Carbon */
                 $paidUntil = $subscription->getPaidUntil()
                     ->copy();
@@ -510,7 +488,6 @@ class UserProductService
         // we only want to update the expiration date of non-payment plan subscription products
         if ($subscription->getType() != Subscription::TYPE_PAYMENT_PLAN) {
             foreach ($products as $productData) {
-
                 /** @var $paidUntil Carbon */
                 $paidUntil = $subscription->getPaidUntil()
                     ->copy();
@@ -518,7 +495,9 @@ class UserProductService
                 $this->assignUserProduct(
                     $subscription->getUser(),
                     $productData['product'],
-                    $paidUntil->addDays(config('ecommerce.days_before_access_revoked_after_expiry_in_app_purchases_only', 5))
+                    $paidUntil->addDays(
+                        config('ecommerce.days_before_access_revoked_after_expiry_in_app_purchases_only', 5)
+                    )
                 );
             }
         }
@@ -527,7 +506,7 @@ class UserProductService
     /**
      * If the user has or had any digital product from brand, return true. Otherwise, false.
      *
-     * @param  User  $user
+     * @param User $user
      * @param $brand
      * @throws Throwable
      */
@@ -546,5 +525,10 @@ class UserProductService
             ->setParameter('brand', $brand);
 
         return $qb->getQuery()->getSingleScalarResult() > 0;
+    }
+
+    public function getLatestExpirationDateByBrand(User $user, string $brand)
+    {
+        return $this->userProductRepository->getLatestExpirationDateByBrand($user, $brand);
     }
 }

--- a/tests/Functional/Ordering/OneTimeProductTest.php
+++ b/tests/Functional/Ordering/OneTimeProductTest.php
@@ -1,0 +1,264 @@
+<?php
+
+namespace Railroad\Ecommerce\Tests\Functional\Ordering;
+
+use Carbon\Carbon;
+use Illuminate\Auth\AuthManager;
+use Illuminate\Auth\SessionGuard;
+use Illuminate\Foundation\Testing\WithoutMiddleware;
+use PHPUnit\Framework\MockObject\MockObject;
+use Railroad\Ecommerce\Entities\Payment;
+use Railroad\Ecommerce\Entities\PaymentMethod;
+use Railroad\Ecommerce\Entities\Product;
+use Railroad\Ecommerce\Entities\Structures\Address;
+use Railroad\Ecommerce\Entities\Subscription;
+use Railroad\Ecommerce\Repositories\SubscriptionRepository;
+use Railroad\Ecommerce\Repositories\UserProductRepository;
+use Railroad\Ecommerce\Services\CartAddressService;
+use Railroad\Ecommerce\Services\CartService;
+use Railroad\Ecommerce\Services\SubscriptionService;
+use Railroad\Ecommerce\Services\TaxService;
+use Railroad\Ecommerce\Tests\Data\DataHelper;
+use Railroad\Ecommerce\Tests\EcommerceTestCase;
+use Stripe\Card;
+use Stripe\Charge;
+use Stripe\Customer;
+use Stripe\Token;
+
+class OneTimeProductTest extends EcommerceTestCase
+{
+    use WithoutMiddleware;
+
+    /**
+     * @var CartService
+     */
+    protected $cartService;
+
+    /**
+     * @var CartAddressService
+     */
+    protected $cartAddressService;
+
+    /**
+     * @var TaxService
+     */
+    protected $taxService;
+
+    /**
+     * @var SubscriptionService
+     */
+    protected $subscriptionService;
+
+    /**
+     * @var SubscriptionRepository
+     */
+    protected $subscriptionRepository;
+
+    /**
+     * @var MockObject|AuthManager
+     */
+    protected $authManagerMock;
+
+    /**
+     * @var MockObject|SessionGuard
+     */
+    protected $sessionGuardMock;
+    protected $userProductRepository;
+    protected $brand;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->cartService = $this->app->make(CartService::class);
+        $this->cartAddressService = $this->app->make(CartAddressService::class);
+        $this->taxService = $this->app->make(TaxService::class);
+        $this->subscriptionService = $this->app->make(SubscriptionService::class);
+        $this->subscriptionRepository = $this->app->make(SubscriptionRepository::class);
+        $this->userProductRepository = $this->app->make(UserProductRepository::class);
+
+        $this->brand = 'drumeo';
+        config()->set('ecommerce.brand', $this->brand);
+    }
+
+    /**
+     * @param array $data
+     * @return Product
+     */
+    public function oneTimeProduct(array $override = []): array
+    {
+        $data = array_merge([
+            'active' => 1,
+            'is_physical' => 0,
+            'weight' => 0,
+            'brand' => $this->brand,
+            'type' => 'digital one time',
+            'subscription_interval_type' => 'year',
+            'subscription_interval_count' => 1,
+            'digital_access_time_interval_type' => 'year',
+            'digital_access_time_type' => 'one time',
+            'digital_access_time_interval_length' => 1
+        ], $override);
+        return $this->fakeProduct($data);
+    }
+
+
+    /**
+     * @param array $data
+     * @return Product
+     */
+    public function subscriptionProduct(array $override = []): array
+    {
+        $data = array_merge([
+            'active' => 1,
+            'is_physical' => 0,
+            'weight' => 0,
+            'brand' => $this->brand,
+            'type' => 'digital subscription',
+            'subscription_interval_type' => 'year',
+            'subscription_interval_count' => 1,
+            'digital_access_time_interval_type' => 'year',
+            'digital_access_time_type' => 'recurring',
+            'digital_access_time_interval_length' => 1
+        ], $override);
+        return $this->fakeProduct($data);
+    }
+
+    public function getCreditCardRequestData()
+    {
+        return [
+            'payment_method_type' => PaymentMethod::TYPE_CREDIT_CARD,
+            'card_token' => $this->faker->word,
+            'billing_region' => 'Ohio',
+            'billing_zip_or_postal_code' => $this->faker->word,
+            'billing_country' => 'United States',
+            'gateway' => $this->brand,
+            'payment_plan_number_of_payments' => 1,
+            'currency' => 'USD',
+        ];
+    }
+
+    /**
+     * @param $fingerPrint
+     */
+    protected function newStripePaymentMocks($fingerPrint = null)
+    {
+        $this->stripeExternalHelperMock->method('getCustomersByEmail')
+            ->willReturn(['data' => '']);
+        $fakerCustomer = new Customer($this->faker->word . rand());
+        $fakerCustomer->email = $this->faker->email;
+        $this->stripeExternalHelperMock->method('createCustomer')
+            ->willReturn($fakerCustomer);
+        $this->stripeExternalHelperMock->method('retrieveCustomer')
+            ->willReturn($fakerCustomer);
+
+        $fakerCard = new Card($this->faker->word);
+        $fakerCard->fingerprint = $fingerPrint ?? $this->faker->word . $this->faker->randomNumber(6);
+        $fakerCard->brand = $this->faker->word;
+        $fakerCard->last4 = $this->faker->randomNumber(4);
+        $fakerCard->exp_year = 2020;
+        $fakerCard->exp_month = 12;
+        $fakerCard->customer = $fakerCustomer->id;
+        $fakerCard->name = $this->faker->word;
+        $this->stripeExternalHelperMock->method('createCard')
+            ->willReturn($fakerCard);
+        $this->stripeExternalHelperMock->method('retrieveCard')
+            ->willReturn($fakerCard);
+
+        $fakerCharge = new Charge($this->faker->word);
+        $fakerCharge->currency = 'cad';
+        $fakerCharge->amount = 100;
+        $fakerCharge->status = 'succeeded';
+        $this->stripeExternalHelperMock->method('chargeCard')
+            ->willReturn($fakerCharge);
+
+        $fakerToken = new Token();
+        $this->stripeExternalHelperMock->method('retrieveToken')
+            ->willReturn($fakerToken);
+    }
+
+    public function purchaseProduct(array $product)
+    {
+        $this->newStripePaymentMocks();
+
+        $this->cartService->addToCart($product['sku'], 1);
+
+        $response = $this->call(
+            'PUT',
+            '/json/order-form/submit',
+            $this->getCreditCardRequestData()
+        );
+    }
+
+    public function test_one_time_product_extends_subscription()
+    {
+        $userId = $this->createAndLogInNewUser();
+
+        $product = $this->subscriptionProduct();
+        $this->purchaseProduct($product);
+        $product = $this->oneTimeProduct();
+        $this->purchaseProduct($product);
+
+        $this->assertDatabaseHas(
+            'ecommerce_subscriptions',
+            [
+                'brand' => $this->brand,
+                'user_id' => $userId,
+                'is_active' => 1,
+                'paid_until' => Carbon::now()->addYear(2)->toDateTimeString(),
+            ]
+        );
+    }
+
+    /**
+     * Test buying another one time product
+     * if original one time product is not expired
+     * @return void
+     */
+    public function test_one_time_multiple_product_nonexpired()
+    {
+        $userId = $this->createAndLogInNewUser();
+
+        $product = $this->oneTimeProduct();
+        $this->purchaseProduct($product);
+        Carbon::setTestNow(Carbon::now()->addMonth(6));
+        $this->purchaseProduct($product);
+
+        $this->assertDatabaseHas(
+            'ecommerce_user_products',
+            [
+                'user_id' => $userId,
+                'quantity' => 2,
+                'expiration_date' => Carbon::now()->addMonth(18)->addDays(
+                    config('ecommerce.days_before_access_revoked_after_expiry', 5)
+                )->toDateTimeString(),
+            ]
+        );
+    }
+
+    /**
+     * Test buying another one time product
+     * if original one time product is expired
+     * @return void
+     */
+    public function test_one_time_multiple_product_expired()
+    {
+        $userId = $this->createAndLogInNewUser();
+
+        $product = $this->oneTimeProduct();
+        $this->purchaseProduct($product);
+        Carbon::setTestNow(Carbon::now()->addMonth(18));
+        $this->purchaseProduct($product);
+
+        $this->assertDatabaseHas(
+            'ecommerce_user_products',
+            [
+                'user_id' => $userId,
+                'quantity' => 2,
+                'expiration_date' => Carbon::now()->addYear(1)->addDays(
+                    config('ecommerce.days_before_access_revoked_after_expiry', 5)
+                )->toDateTimeString(),
+            ]
+        );
+    }
+}

--- a/tests/Functional/Ordering/OneTimeProductTest.php
+++ b/tests/Functional/Ordering/OneTimeProductTest.php
@@ -222,13 +222,14 @@ class OneTimeProductTest extends EcommerceTestCase
         $product = $this->oneTimeProduct();
         $this->purchaseProduct($product);
         Carbon::setTestNow(Carbon::now()->addMonth(6));
+        $product = $this->oneTimeProduct();
         $this->purchaseProduct($product);
 
         $this->assertDatabaseHas(
             'ecommerce_user_products',
             [
                 'user_id' => $userId,
-                'quantity' => 2,
+                'product_id' => $product['id'],
                 'expiration_date' => Carbon::now()->addMonth(18)->addDays(
                     config('ecommerce.days_before_access_revoked_after_expiry', 5)
                 )->toDateTimeString(),
@@ -248,13 +249,41 @@ class OneTimeProductTest extends EcommerceTestCase
         $product = $this->oneTimeProduct();
         $this->purchaseProduct($product);
         Carbon::setTestNow(Carbon::now()->addMonth(18));
+        $product = $this->oneTimeProduct();
         $this->purchaseProduct($product);
 
         $this->assertDatabaseHas(
             'ecommerce_user_products',
             [
                 'user_id' => $userId,
-                'quantity' => 2,
+                'product_id' => $product['id'],
+                'expiration_date' => Carbon::now()->addYear(1)->addDays(
+                    config('ecommerce.days_before_access_revoked_after_expiry', 5)
+                )->toDateTimeString(),
+            ]
+        );
+    }
+
+    /**
+     * Test buying another one time product
+     * if original one time product is expired
+     * @return void
+     */
+    public function test_one_time_multiple_product_different_brands()
+    {
+        $userId = $this->createAndLogInNewUser();
+
+        $product = $this->oneTimeProduct(['brand' => 'drumeo']);
+        $this->purchaseProduct($product);
+        Carbon::setTestNow(Carbon::now()->addMonth(6));
+        $product = $this->oneTimeProduct(['brand' => 'pianote']);
+        $this->purchaseProduct($product);
+
+        $this->assertDatabaseHas(
+            'ecommerce_user_products',
+            [
+                'user_id' => $userId,
+                'product_id' => $product['id'],
                 'expiration_date' => Carbon::now()->addYear(1)->addDays(
                     config('ecommerce.days_before_access_revoked_after_expiry', 5)
                 )->toDateTimeString(),


### PR DESCRIPTION
Issue: https://musoraproduct.myjetbrains.com/youtrack/issue/BR-331
One time membership products do not correctly update the active subscription time causing subscriptions to be processed earlier than expected

Solution:
Added a listener to process new one time products and extend the subscription paid_until time as required.
Also sync the subscriptions associated user product expiration_date as well

Included an ecommerce artisan command
r pianote artisan GetOneTimeProductSubscriptionIssues
Running this will generate a list of possible issues and give you the option to attempt to resolve them automatically.
There are about 40 remaining issues
If you rerun the command there is one issue monthly singeo membership that extends until october for some reason, which is not solved on the first pass.  

Other Issues:  
If you buy a one time membership and then a recurring membership the new membership should start after the one time finishes
Buying multiple one time memberships does not increment the user product expiration date correctly