### PR TITLE
Fix for expiration date on multiple one time product orders

### DIFF
--- a/src/Listeners/OrderOneTimeProductListener.php
+++ b/src/Listeners/OrderOneTimeProductListener.php
@@ -6,6 +6,7 @@ use Carbon\Carbon;
 use Doctrine\ORM\NonUniqueResultException;
 use Faker\Provider\DateTime;
 use Railroad\Ecommerce\Entities\Product;
+use Railroad\Ecommerce\Entities\Subscription;
 use Railroad\Ecommerce\Events\OrderEvent;
 use Railroad\Ecommerce\Events\Subscriptions\SubscriptionUpdated;
 use Railroad\Ecommerce\Managers\EcommerceEntityManager;
@@ -70,7 +71,10 @@ class OrderOneTimeProductListener
         $subscriptions = collect(
             $this->subscriptionRepository->getActiveSubscriptionsByUserId($order->getUser()->getId())
         );
-        $subscriptionsMap = $subscriptions->mapWithKeys(function ($subscription, $key) {
+        $subscriptionsMap = $subscriptions->sortBy(function (Subscription $subscription) {
+            //mapWithKeys takes the last value for duplicate keys which is why we sort by ascending here
+            return $subscription->getPaidUntil();
+        })->mapWithKeys(function ($subscription, $key) {
             return [$subscription->getBrand() => $subscription];
         });
 

--- a/src/Listeners/OrderUserProductListener.php
+++ b/src/Listeners/OrderUserProductListener.php
@@ -79,7 +79,7 @@ class OrderUserProductListener
                     !empty($product->getSubscriptionIntervalType()) &&
                     !empty($product->getSubscriptionIntervalCount())) {
                     $userProduct = $this->userProductService->getUserProduct($order->getUser(), $product);
-                    $start = $userProduct->getExpirationDate()->copy() ?? Carbon::now();
+                    $start = ($userProduct ? $userProduct->getExpirationDate()->copy() : null) ?? Carbon::now();
                     $intervalType = $product->getSubscriptionIntervalType();
                     $nIntervals = $product->getSubscriptionIntervalCount() * $orderItem->getQuantity();
 

--- a/src/Services/UserProductService.php
+++ b/src/Services/UserProductService.php
@@ -47,8 +47,7 @@ class UserProductService
     public function __construct(
         EcommerceEntityManager $entityManager,
         UserProductRepository $userProductRepository
-    )
-    {
+    ) {
         $this->entityManager = $entityManager;
         $this->userProductRepository = $userProductRepository;
 
@@ -71,7 +70,6 @@ class UserProductService
             if ($userProduct->getProduct()
                     ->getId() == $productId &&
                 ($userProduct->isValid())) {
-
                 return true;
             }
         }
@@ -98,7 +96,6 @@ class UserProductService
                     $productIds
                 ) &&
                 ($userProduct->isValid())) {
-
                 return true;
             }
         }
@@ -119,10 +116,8 @@ class UserProductService
         $userProducts = $this->getAllUsersProducts($userId);
 
         foreach ($userProducts as $userProduct) {
-
             if ($userProduct->getProduct()
                     ->getId() == $productId) {
-
                 if ($userProduct->getExpirationDate() == null) {
                     return null;
                 }
@@ -192,9 +187,7 @@ class UserProductService
     public function getUserProduct(
         User $user,
         Product $product
-    ): ?UserProduct
-    {
-
+    ): ?UserProduct {
         /** @var $qb QueryBuilder */
         $qb = $this->userProductRepository->createQueryBuilder('up');
 
@@ -210,7 +203,7 @@ class UserProductService
             ->setParameter('product', $product);
 
         return $qb->getQuery()
-            ->getResult()[0] ?? null;
+                ->getResult()[0] ?? null;
     }
 
     /**
@@ -224,8 +217,7 @@ class UserProductService
     public function getUserProducts(
         User $user,
         $products
-    ): array
-    {
+    ): array {
         /** @var $qb QueryBuilder */
         $qb = $this->userProductRepository->createQueryBuilder('up');
 
@@ -273,9 +265,7 @@ class UserProductService
         Product $product,
         ?DateTimeInterface $expirationDate,
         $quantity
-    ): UserProduct
-    {
-
+    ): UserProduct {
         $userProduct = new UserProduct();
 
         $userProduct->setUser($user);
@@ -306,8 +296,7 @@ class UserProductService
         UserProduct $userProduct,
         ?DateTimeInterface $expirationDate,
         $quantity
-    )
-    {
+    ) {
         $oldUserProduct = clone($userProduct);
 
         $userProduct->setExpirationDate($expirationDate);
@@ -352,8 +341,7 @@ class UserProductService
         Product $product,
         ?DateTimeInterface $expirationDate,
         $quantity = 0
-    )
-    {
+    ) {
         /**
          * @var $userProduct UserProduct
          */
@@ -362,8 +350,7 @@ class UserProductService
         if (!$userProduct) {
             $productQuantity = ($quantity == 0) ? 1 : $quantity;
             $this->createUserProduct($user, $product, $expirationDate, $productQuantity);
-        }
-        else {
+        } else {
             $this->updateUserProduct($userProduct, $expirationDate, ($userProduct->getQuantity() + $quantity));
         }
     }
@@ -383,8 +370,7 @@ class UserProductService
     public function removeUserProducts(
         User $user,
         $products
-    )
-    {
+    ) {
         $userProducts = $this->getUserProducts(
             $user,
             $products->pluck('product')
@@ -392,7 +378,6 @@ class UserProductService
         );
 
         foreach ($products as $productData) {
-
             /**
              * @var $product Product
              */
@@ -410,9 +395,7 @@ class UserProductService
                 $this->entityManager->remove($userProduct);
 
                 event(new UserProductDeleted($userProduct));
-            }
-            else {
-
+            } else {
                 $quantity = $userProduct->getQuantity() - $productData['quantity'];
 
                 $userProduct->setQuantity($quantity);
@@ -436,7 +419,6 @@ class UserProductService
     public function getSubscriptionProducts(Subscription $subscription)
     {
         if ($subscription->getType() == config('ecommerce.type_payment_plan')) {
-
             if (!$subscription->getOrder()) {
                 return collect([]);
             }
@@ -453,10 +435,7 @@ class UserProductService
                     ];
                 }
             );
-
-        }
-        else {
-
+        } else {
             return collect(
                 [
                     [
@@ -482,7 +461,6 @@ class UserProductService
         // we only want to update the expiration date of non-payment plan subscription products
         if ($subscription->getType() != Subscription::TYPE_PAYMENT_PLAN) {
             foreach ($products as $productData) {
-
                 /** @var $paidUntil Carbon */
                 $paidUntil = $subscription->getPaidUntil()
                     ->copy();
@@ -510,7 +488,6 @@ class UserProductService
         // we only want to update the expiration date of non-payment plan subscription products
         if ($subscription->getType() != Subscription::TYPE_PAYMENT_PLAN) {
             foreach ($products as $productData) {
-
                 /** @var $paidUntil Carbon */
                 $paidUntil = $subscription->getPaidUntil()
                     ->copy();
@@ -518,7 +495,9 @@ class UserProductService
                 $this->assignUserProduct(
                     $subscription->getUser(),
                     $productData['product'],
-                    $paidUntil->addDays(config('ecommerce.days_before_access_revoked_after_expiry_in_app_purchases_only', 5))
+                    $paidUntil->addDays(
+                        config('ecommerce.days_before_access_revoked_after_expiry_in_app_purchases_only', 5)
+                    )
                 );
             }
         }
@@ -527,7 +506,7 @@ class UserProductService
     /**
      * If the user has or had any digital product from brand, return true. Otherwise, false.
      *
-     * @param  User  $user
+     * @param User $user
      * @param $brand
      * @throws Throwable
      */
@@ -546,5 +525,10 @@ class UserProductService
             ->setParameter('brand', $brand);
 
         return $qb->getQuery()->getSingleScalarResult() > 0;
+    }
+
+    public function getLatestExpirationDateByBrand(User $user, string $brand)
+    {
+        return $this->userProductRepository->getLatestExpirationDateByBrand($user, $brand);
     }
 }

--- a/tests/Functional/Ordering/OneTimeProductTest.php
+++ b/tests/Functional/Ordering/OneTimeProductTest.php
@@ -1,0 +1,264 @@
+<?php
+
+namespace Railroad\Ecommerce\Tests\Functional\Ordering;
+
+use Carbon\Carbon;
+use Illuminate\Auth\AuthManager;
+use Illuminate\Auth\SessionGuard;
+use Illuminate\Foundation\Testing\WithoutMiddleware;
+use PHPUnit\Framework\MockObject\MockObject;
+use Railroad\Ecommerce\Entities\Payment;
+use Railroad\Ecommerce\Entities\PaymentMethod;
+use Railroad\Ecommerce\Entities\Product;
+use Railroad\Ecommerce\Entities\Structures\Address;
+use Railroad\Ecommerce\Entities\Subscription;
+use Railroad\Ecommerce\Repositories\SubscriptionRepository;
+use Railroad\Ecommerce\Repositories\UserProductRepository;
+use Railroad\Ecommerce\Services\CartAddressService;
+use Railroad\Ecommerce\Services\CartService;
+use Railroad\Ecommerce\Services\SubscriptionService;
+use Railroad\Ecommerce\Services\TaxService;
+use Railroad\Ecommerce\Tests\Data\DataHelper;
+use Railroad\Ecommerce\Tests\EcommerceTestCase;
+use Stripe\Card;
+use Stripe\Charge;
+use Stripe\Customer;
+use Stripe\Token;
+
+class OneTimeProductTest extends EcommerceTestCase
+{
+    use WithoutMiddleware;
+
+    /**
+     * @var CartService
+     */
+    protected $cartService;
+
+    /**
+     * @var CartAddressService
+     */
+    protected $cartAddressService;
+
+    /**
+     * @var TaxService
+     */
+    protected $taxService;
+
+    /**
+     * @var SubscriptionService
+     */
+    protected $subscriptionService;
+
+    /**
+     * @var SubscriptionRepository
+     */
+    protected $subscriptionRepository;
+
+    /**
+     * @var MockObject|AuthManager
+     */
+    protected $authManagerMock;
+
+    /**
+     * @var MockObject|SessionGuard
+     */
+    protected $sessionGuardMock;
+    protected $userProductRepository;
+    protected $brand;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->cartService = $this->app->make(CartService::class);
+        $this->cartAddressService = $this->app->make(CartAddressService::class);
+        $this->taxService = $this->app->make(TaxService::class);
+        $this->subscriptionService = $this->app->make(SubscriptionService::class);
+        $this->subscriptionRepository = $this->app->make(SubscriptionRepository::class);
+        $this->userProductRepository = $this->app->make(UserProductRepository::class);
+
+        $this->brand = 'drumeo';
+        config()->set('ecommerce.brand', $this->brand);
+    }
+
+    /**
+     * @param array $data
+     * @return Product
+     */
+    public function oneTimeProduct(array $override = []): array
+    {
+        $data = array_merge([
+            'active' => 1,
+            'is_physical' => 0,
+            'weight' => 0,
+            'brand' => $this->brand,
+            'type' => 'digital one time',
+            'subscription_interval_type' => 'year',
+            'subscription_interval_count' => 1,
+            'digital_access_time_interval_type' => 'year',
+            'digital_access_time_type' => 'one time',
+            'digital_access_time_interval_length' => 1
+        ], $override);
+        return $this->fakeProduct($data);
+    }
+
+
+    /**
+     * @param array $data
+     * @return Product
+     */
+    public function subscriptionProduct(array $override = []): array
+    {
+        $data = array_merge([
+            'active' => 1,
+            'is_physical' => 0,
+            'weight' => 0,
+            'brand' => $this->brand,
+            'type' => 'digital subscription',
+            'subscription_interval_type' => 'year',
+            'subscription_interval_count' => 1,
+            'digital_access_time_interval_type' => 'year',
+            'digital_access_time_type' => 'recurring',
+            'digital_access_time_interval_length' => 1
+        ], $override);
+        return $this->fakeProduct($data);
+    }
+
+    public function getCreditCardRequestData()
+    {
+        return [
+            'payment_method_type' => PaymentMethod::TYPE_CREDIT_CARD,
+            'card_token' => $this->faker->word,
+            'billing_region' => 'Ohio',
+            'billing_zip_or_postal_code' => $this->faker->word,
+            'billing_country' => 'United States',
+            'gateway' => $this->brand,
+            'payment_plan_number_of_payments' => 1,
+            'currency' => 'USD',
+        ];
+    }
+
+    /**
+     * @param $fingerPrint
+     */
+    protected function newStripePaymentMocks($fingerPrint = null)
+    {
+        $this->stripeExternalHelperMock->method('getCustomersByEmail')
+            ->willReturn(['data' => '']);
+        $fakerCustomer = new Customer($this->faker->word . rand());
+        $fakerCustomer->email = $this->faker->email;
+        $this->stripeExternalHelperMock->method('createCustomer')
+            ->willReturn($fakerCustomer);
+        $this->stripeExternalHelperMock->method('retrieveCustomer')
+            ->willReturn($fakerCustomer);
+
+        $fakerCard = new Card($this->faker->word);
+        $fakerCard->fingerprint = $fingerPrint ?? $this->faker->word . $this->faker->randomNumber(6);
+        $fakerCard->brand = $this->faker->word;
+        $fakerCard->last4 = $this->faker->randomNumber(4);
+        $fakerCard->exp_year = 2020;
+        $fakerCard->exp_month = 12;
+        $fakerCard->customer = $fakerCustomer->id;
+        $fakerCard->name = $this->faker->word;
+        $this->stripeExternalHelperMock->method('createCard')
+            ->willReturn($fakerCard);
+        $this->stripeExternalHelperMock->method('retrieveCard')
+            ->willReturn($fakerCard);
+
+        $fakerCharge = new Charge($this->faker->word);
+        $fakerCharge->currency = 'cad';
+        $fakerCharge->amount = 100;
+        $fakerCharge->status = 'succeeded';
+        $this->stripeExternalHelperMock->method('chargeCard')
+            ->willReturn($fakerCharge);
+
+        $fakerToken = new Token();
+        $this->stripeExternalHelperMock->method('retrieveToken')
+            ->willReturn($fakerToken);
+    }
+
+    public function purchaseProduct(array $product)
+    {
+        $this->newStripePaymentMocks();
+
+        $this->cartService->addToCart($product['sku'], 1);
+
+        $response = $this->call(
+            'PUT',
+            '/json/order-form/submit',
+            $this->getCreditCardRequestData()
+        );
+    }
+
+    public function test_one_time_product_extends_subscription()
+    {
+        $userId = $this->createAndLogInNewUser();
+
+        $product = $this->subscriptionProduct();
+        $this->purchaseProduct($product);
+        $product = $this->oneTimeProduct();
+        $this->purchaseProduct($product);
+
+        $this->assertDatabaseHas(
+            'ecommerce_subscriptions',
+            [
+                'brand' => $this->brand,
+                'user_id' => $userId,
+                'is_active' => 1,
+                'paid_until' => Carbon::now()->addYear(2)->toDateTimeString(),
+            ]
+        );
+    }
+
+    /**
+     * Test buying another one time product
+     * if original one time product is not expired
+     * @return void
+     */
+    public function test_one_time_multiple_product_nonexpired()
+    {
+        $userId = $this->createAndLogInNewUser();
+
+        $product = $this->oneTimeProduct();
+        $this->purchaseProduct($product);
+        Carbon::setTestNow(Carbon::now()->addMonth(6));
+        $this->purchaseProduct($product);
+
+        $this->assertDatabaseHas(
+            'ecommerce_user_products',
+            [
+                'user_id' => $userId,
+                'quantity' => 2,
+                'expiration_date' => Carbon::now()->addMonth(18)->addDays(
+                    config('ecommerce.days_before_access_revoked_after_expiry', 5)
+                )->toDateTimeString(),
+            ]
+        );
+    }
+
+    /**
+     * Test buying another one time product
+     * if original one time product is expired
+     * @return void
+     */
+    public function test_one_time_multiple_product_expired()
+    {
+        $userId = $this->createAndLogInNewUser();
+
+        $product = $this->oneTimeProduct();
+        $this->purchaseProduct($product);
+        Carbon::setTestNow(Carbon::now()->addMonth(18));
+        $this->purchaseProduct($product);
+
+        $this->assertDatabaseHas(
+            'ecommerce_user_products',
+            [
+                'user_id' => $userId,
+                'quantity' => 2,
+                'expiration_date' => Carbon::now()->addYear(1)->addDays(
+                    config('ecommerce.days_before_access_revoked_after_expiry', 5)
+                )->toDateTimeString(),
+            ]
+        );
+    }
+}

--- a/tests/Functional/Ordering/OneTimeProductTest.php
+++ b/tests/Functional/Ordering/OneTimeProductTest.php
@@ -222,13 +222,14 @@ class OneTimeProductTest extends EcommerceTestCase
         $product = $this->oneTimeProduct();
         $this->purchaseProduct($product);
         Carbon::setTestNow(Carbon::now()->addMonth(6));
+        $product = $this->oneTimeProduct();
         $this->purchaseProduct($product);
 
         $this->assertDatabaseHas(
             'ecommerce_user_products',
             [
                 'user_id' => $userId,
-                'quantity' => 2,
+                'product_id' => $product['id'],
                 'expiration_date' => Carbon::now()->addMonth(18)->addDays(
                     config('ecommerce.days_before_access_revoked_after_expiry', 5)
                 )->toDateTimeString(),
@@ -248,13 +249,41 @@ class OneTimeProductTest extends EcommerceTestCase
         $product = $this->oneTimeProduct();
         $this->purchaseProduct($product);
         Carbon::setTestNow(Carbon::now()->addMonth(18));
+        $product = $this->oneTimeProduct();
         $this->purchaseProduct($product);
 
         $this->assertDatabaseHas(
             'ecommerce_user_products',
             [
                 'user_id' => $userId,
-                'quantity' => 2,
+                'product_id' => $product['id'],
+                'expiration_date' => Carbon::now()->addYear(1)->addDays(
+                    config('ecommerce.days_before_access_revoked_after_expiry', 5)
+                )->toDateTimeString(),
+            ]
+        );
+    }
+
+    /**
+     * Test buying another one time product
+     * if original one time product is expired
+     * @return void
+     */
+    public function test_one_time_multiple_product_different_brands()
+    {
+        $userId = $this->createAndLogInNewUser();
+
+        $product = $this->oneTimeProduct(['brand' => 'drumeo']);
+        $this->purchaseProduct($product);
+        Carbon::setTestNow(Carbon::now()->addMonth(6));
+        $product = $this->oneTimeProduct(['brand' => 'pianote']);
+        $this->purchaseProduct($product);
+
+        $this->assertDatabaseHas(
+            'ecommerce_user_products',
+            [
+                'user_id' => $userId,
+                'product_id' => $product['id'],
                 'expiration_date' => Carbon::now()->addYear(1)->addDays(
                     config('ecommerce.days_before_access_revoked_after_expiry', 5)
                 )->toDateTimeString(),


### PR DESCRIPTION
Issue:
Purchasing the same one time product only increments the expiration date for a single purchase, can lose previous purchased time if product not already expired.

Solution:
Look up existing expiration date if exists and add the time purchased to get the new expiration date.