### PR TITLE
Fix for subscriptions not canceled when other membership product purchased

### DIFF
--- a/src/Listeners/DuplicateSubscriptionHandler.php
+++ b/src/Listeners/DuplicateSubscriptionHandler.php
@@ -5,6 +5,7 @@ namespace Railroad\Ecommerce\Listeners;
 use Carbon\Carbon;
 use Doctrine\ORM\OptimisticLockException;
 use Doctrine\ORM\ORMException;
+use Railroad\Ecommerce\Entities\Product;
 use Railroad\Ecommerce\Entities\Subscription;
 use Railroad\Ecommerce\Events\OrderEvent;
 use Railroad\Ecommerce\Events\Subscriptions\SubscriptionUpdated;
@@ -61,7 +62,6 @@ class DuplicateSubscriptionHandler
             if (!empty($orderEvent->getOrder()->getUser())) {
                 $this->cancelAndExtendDuplicateSubscriptions($orderEvent->getOrder()->getUser()->getId());
             }
-
         } catch (Throwable $exception) {
             error_log('--- Error with duplicate subscription handling in ecommerce package.');
             error_log($exception);
@@ -80,38 +80,83 @@ class DuplicateSubscriptionHandler
         $allUsersSubscriptions = $this->subscriptionRepository->getAllUsersSubscriptions($userId);
         $userProducts = $this->userProductRepository->getAllUsersProducts($userId);
 
-        // for each brand
-        foreach (config('ecommerce.membership_product_syncing_info', []) as $brand => $syncData) {
+        // check if they are a lifetime member
+        $userIsLifetimeMember = false;
 
-            // get all membership product skus
-            $membershipProductSkus = $syncData['membership_product_skus'] ?? [];
-
-            if (empty($membershipProductSkus)) {
-                return;
+        foreach ($userProducts as $userProduct) {
+            if ($userProduct->isValid() &&
+                empty($userProduct->getExpirationDate()) &&
+                $userProduct->getProduct()->isMembershipProduct() &&
+                $userProduct->getProduct()->getDigitalAccessTimeType() == Product::DIGITAL_ACCESS_TIME_TYPE_LIFETIME) {
+                $userIsLifetimeMember = true;
             }
+        }
 
-            // check if they are a lifetime member
-            $userIsLifetimeMember = false;
+        // if they are a lifetime member, cancel all active membership subscriptions
+        if ($userIsLifetimeMember) {
+            foreach ($allUsersSubscriptions as $userSubscription) {
+                if (!empty($userSubscription->getProduct()) &&
+                    $userProduct->getProduct()->isMembershipProduct() &&
+                    $userSubscription->getIsActive()) {
+                    $oldUserSubscription = clone($userSubscription);
 
-            foreach ($userProducts as $userProduct) {
-                if ($userProduct->getProduct()->getBrand() == $brand &&
-                    $userProduct->isValid() &&
-                    empty($userProduct->getExpirationDate()) &&
-                    in_array($userProduct->getProduct()->getSku(), $membershipProductSkus)) {
-                    $userIsLifetimeMember = true;
+                    $userSubscription->setIsActive(false);
+                    $userSubscription->setCanceledOn(Carbon::now());
+
+                    $this->ecommerceEntityManager->persist($userSubscription);
+                    $this->ecommerceEntityManager->flush($userSubscription);
+
+                    event(new SubscriptionUpdated($oldUserSubscription, $userSubscription));
+                }
+            }
+        } else {
+            // otherwise, find all duplicate subscriptions with an expiration date in the future,
+            // add up their remaining time, then set the latest active one with that expiration date
+            $totalMinutes = 0;
+
+            /**
+             * @var $mostRecentlyPurchasedActiveSubscription Subscription|null
+             */
+            $mostRecentlyPurchasedActiveSubscription = null;
+
+            // extend the date of the most recently created subscription
+            foreach ($allUsersSubscriptions as $userSubscription) {
+                if (!empty($userSubscription->getProduct()) &&
+                    $userProduct->getProduct()->isMembershipProduct() &&
+                    $userSubscription->getPaidUntil() > Carbon::now() &&
+                    $userSubscription->getIsActive()) {
+                    $totalMinutes += Carbon::now()->diffInMinutes($userSubscription->getPaidUntil());
+
+                    if ($userSubscription->getIsActive() &&
+                        empty($userSubscription->getCanceledOn())) {
+                        if (empty($mostRecentlyPurchasedActiveSubscription) ||
+                            $mostRecentlyPurchasedActiveSubscription->getCreatedAt() < $userSubscription->getCreatedAt(
+                            )) {
+                            $mostRecentlyPurchasedActiveSubscription = $userSubscription;
+                        }
+                    }
                 }
             }
 
-            // if they are a lifetime member, cancel all active membership subscriptions
-            if ($userIsLifetimeMember) {
+            if (!empty($mostRecentlyPurchasedActiveSubscription)) {
+                $oldUserSubscription = clone($mostRecentlyPurchasedActiveSubscription);
 
+                $mostRecentlyPurchasedActiveSubscription->setPaidUntil(Carbon::now()->addMinutes($totalMinutes));
+
+                $this->ecommerceEntityManager->persist($mostRecentlyPurchasedActiveSubscription);
+                $this->ecommerceEntityManager->flush($mostRecentlyPurchasedActiveSubscription);
+
+                event(new SubscriptionUpdated($oldUserSubscription, $mostRecentlyPurchasedActiveSubscription));
+
+                $this->userProductService->updateSubscriptionProducts($mostRecentlyPurchasedActiveSubscription);
+
+                // cancel all the other ones
                 foreach ($allUsersSubscriptions as $userSubscription) {
-
                     if (!empty($userSubscription->getProduct()) &&
-                        $userSubscription->getProduct()->getBrand() == $brand &&
-                        in_array($userSubscription->getProduct()->getSku(), $membershipProductSkus) &&
-                        $userSubscription->getIsActive()) {
-
+                        $userProduct->getProduct()->isMembershipProduct() &&
+                        $userSubscription->getPaidUntil() > Carbon::now() &&
+                        $userSubscription->getIsActive() &&
+                        $mostRecentlyPurchasedActiveSubscription->getId() != $userSubscription->getId()) {
                         $oldUserSubscription = clone($userSubscription);
 
                         $userSubscription->setIsActive(false);
@@ -123,74 +168,8 @@ class DuplicateSubscriptionHandler
                         event(new SubscriptionUpdated($oldUserSubscription, $userSubscription));
                     }
                 }
-
-            } else {
-                // otherwise, find all duplicate subscriptions with an expiration date in the future,
-                // add up their remaining time, then set the latest active one with that expiration date
-                $totalMinutes = 0;
-
-                /**
-                 * @var $mostRecentlyPurchasedActiveSubscription Subscription|null
-                 */
-                $mostRecentlyPurchasedActiveSubscription = null;
-
-                // extend the date of the most recently created subscription
-                foreach ($allUsersSubscriptions as $userSubscription) {
-
-                    if (!empty($userSubscription->getProduct()) &&
-                        $userSubscription->getProduct()->getBrand() == $brand &&
-                        in_array($userSubscription->getProduct()->getSku(), $membershipProductSkus) &&
-                        $userSubscription->getPaidUntil() > Carbon::now() &&
-                        $userSubscription->getIsActive()) {
-
-                        $totalMinutes += Carbon::now()->diffInMinutes($userSubscription->getPaidUntil());
-
-                        if ($userSubscription->getIsActive() &&
-                            empty($userSubscription->getCanceledOn())) {
-
-                            if (empty($mostRecentlyPurchasedActiveSubscription) ||
-                                $mostRecentlyPurchasedActiveSubscription->getCreatedAt() < $userSubscription->getCreatedAt()) {
-                                $mostRecentlyPurchasedActiveSubscription = $userSubscription;
-                            }
-                        }
-                    }
-                }
-
-                if (!empty($mostRecentlyPurchasedActiveSubscription)) {
-                    $oldUserSubscription = clone($mostRecentlyPurchasedActiveSubscription);
-
-                    $mostRecentlyPurchasedActiveSubscription->setPaidUntil(Carbon::now()->addMinutes($totalMinutes));
-
-                    $this->ecommerceEntityManager->persist($mostRecentlyPurchasedActiveSubscription);
-                    $this->ecommerceEntityManager->flush($mostRecentlyPurchasedActiveSubscription);
-
-                    event(new SubscriptionUpdated($oldUserSubscription, $mostRecentlyPurchasedActiveSubscription));
-
-                    $this->userProductService->updateSubscriptionProducts($mostRecentlyPurchasedActiveSubscription);
-
-                    // cancel all the other ones
-                    foreach ($allUsersSubscriptions as $userSubscription) {
-
-                        if (!empty($userSubscription->getProduct()) &&
-                            $userSubscription->getProduct()->getBrand() == $brand &&
-                            in_array($userSubscription->getProduct()->getSku(), $membershipProductSkus) &&
-                            $userSubscription->getPaidUntil() > Carbon::now() &&
-                            $userSubscription->getIsActive() &&
-                            $mostRecentlyPurchasedActiveSubscription->getId() != $userSubscription->getId()) {
-
-                            $oldUserSubscription = clone($userSubscription);
-
-                            $userSubscription->setIsActive(false);
-                            $userSubscription->setCanceledOn(Carbon::now());
-
-                            $this->ecommerceEntityManager->persist($userSubscription);
-                            $this->ecommerceEntityManager->flush($userSubscription);
-
-                            event(new SubscriptionUpdated($oldUserSubscription, $userSubscription));
-                        }
-                    }
-                }
             }
         }
     }
+}
 }


### PR DESCRIPTION
https://musoraproduct.myjetbrains.com/youtrack/issue/BR-632

Changed to consider all membership products the same across all brands.
Use IsMembershipProduct instead of a hardcoded array of membership products.