### PR TITLE
Misc updates required by Shopify data sync commands

### DIFF
--- a/src/Entities/OrderItem.php
+++ b/src/Entities/OrderItem.php
@@ -51,6 +51,11 @@ class OrderItem
     protected $orderItemDiscounts;
 
     /**
+     * @ORM\OneToMany(targetEntity="Railroad\Ecommerce\Entities\OrderItemFulfillment", mappedBy="orderItem")
+     */
+    protected $orderItemFulfillments;
+
+    /**
      * @ORM\Column(type="integer")
      *
      * @var int
@@ -243,5 +248,13 @@ class OrderItem
                 $orderDiscount->setOrderItem(null);
             }
         }
+    }
+
+    /**
+     * @return @return Collection|OrderItemFulfillment[]
+     */
+    public function getOrderItemFulfillments(): Collection
+    {
+        return $this->orderItemFulfillments;
     }
 }

--- a/src/Entities/User.php
+++ b/src/Entities/User.php
@@ -3,20 +3,68 @@
 namespace Railroad\Ecommerce\Entities;
 
 use Carbon\Carbon;
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Timestampable\Traits\TimestampableEntity;
 use Railroad\Doctrine\Contracts\UserEntityInterface;
 use Railroad\Ecommerce\Contracts\IdentifiableInterface;
+use Railroad\Ecommerce\Entities\Traits\ShopifyEntity;
 
+/**
+ * @ORM\Entity(repositoryClass="Railroad\Ecommerce\Repositories\UserRepository")
+ * @ORM\Table(
+ *     name="usora_users",
+ * )
+ */
 class User implements UserEntityInterface, IdentifiableInterface
 {
-    /**
-     * @var int
-     */
-    private $id;
+    use TimestampableEntity, ShopifyEntity;
 
     /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue
+     *
+     * @var int
+     */
+    protected $id;
+
+    /**
+     * @ORM\Column(type="string", nullable=true)
+     *
      * @var string
      */
-    private $email;
+    protected $email;
+
+    /**
+     * @ORM\Column(type="string", nullable=true)
+     *
+     * @var string
+     */
+    protected $first_name;
+
+    /**
+     * @ORM\Column(type="string", nullable=true)
+     *
+     * @var string
+     */
+    protected $last_name;
+
+    /**
+     * @ORM\Column(type="string", nullable=true)
+     *
+     * @var string
+     */
+    protected $support_note;
+
+    /**
+     * @ORM\Column(type="string", nullable=true)
+     *
+     * @var string
+     */
+    protected $phone_number;
+
+
+
 
     private ?Carbon $membershipExpirationDate;
 
@@ -65,6 +113,69 @@ class User implements UserEntityInterface, IdentifiableInterface
         $this->email = $email;
     }
 
+    /**
+     * @return string|null
+     */
+    public function getFirstName(): ?string
+    {
+        return $this->first_name;
+    }
+
+    /**
+     * @param string|null $firstName
+     */
+    public function setFirstName(?string $firstName): void
+    {
+        $this->first_name = $firstName;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getLastName(): ?string
+    {
+        return $this->last_name;
+    }
+
+    /**
+     * @param string|null $lastName
+     */
+    public function setLastName(?string $lastName): void
+    {
+        $this->last_name = $lastName;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getSupportNote(): ?string
+    {
+        return $this->support_note;
+    }
+
+    /**
+     * @param string|null $supportNote
+     */
+    public function setSupportNote(?string $supportNote): void
+    {
+        $this->support_note = $supportNote;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getPhoneNumber(): ?string
+    {
+        return $this->phone_number;
+    }
+
+    /**
+     * @param string|null $phoneNumber
+     */
+    public function setPhoneNumber(?string $phoneNumber): void
+    {
+        $this->phone_number = $phoneNumber;
+    }
 
     public function getMembershipExpirationDate(): ?Carbon
     {

--- a/src/Repositories/AddressRepository.php
+++ b/src/Repositories/AddressRepository.php
@@ -165,4 +165,24 @@ class AddressRepository extends RepositoryBase
 
        return $qb;
     }
+
+    /**
+     * @param int $shopifyId
+     * @return Address|null
+     *
+     * @throws \Doctrine\ORM\NonUniqueResultException
+     */
+    public function getByShopifyId(int $shopifyId): ?Address
+    {
+        $qb = $this->createQueryBuilder("a");
+
+        $qb->where(
+            $qb->expr()
+                ->eq("a.shopifyId", ":shopifyId")
+        )->setParameter("shopifyId", $shopifyId);
+
+        return
+            $qb->getQuery()
+                ->getOneOrNullResult();
+    }
 }

--- a/src/Repositories/OrderItemRepository.php
+++ b/src/Repositories/OrderItemRepository.php
@@ -54,4 +54,24 @@ class OrderItemRepository extends RepositoryBase
 
         return $qb->getQuery()->getResult();
     }
+
+    /**
+     * @param int $shopifyId
+     * @return OrderItem|null
+     *
+     * @throws \Doctrine\ORM\NonUniqueResultException
+     */
+    public function getByShopifyId(int $shopifyId): ?OrderItem
+    {
+        $qb = $this->createQueryBuilder("oi");
+
+        $qb->where(
+            $qb->expr()
+                ->eq("oi.shopifyId", ":shopifyId")
+        )->setParameter("shopifyId", $shopifyId);
+
+        return
+            $qb->getQuery()
+                ->getOneOrNullResult();
+    }
 }

--- a/src/Repositories/UserRepository.php
+++ b/src/Repositories/UserRepository.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Railroad\Ecommerce\Repositories;
+
+use Illuminate\Http\Request;
+use Railroad\Ecommerce\Composites\Query\ResultsQueryBuilderComposite;
+use Railroad\Ecommerce\Entities\User;
+use Railroad\Ecommerce\Managers\EcommerceEntityManager;
+use Railroad\Ecommerce\Repositories\Traits\UseFormRequestQueryBuilder;
+
+/**
+ * Class UserRepository
+ *
+ * @method User find($id, $lockMode = null, $lockVersion = null)
+ * @method User findOneBy(array $criteria, array $orderBy = null)
+ * @method User[] findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ * @method User[] findAll()
+ *
+ * @package Railroad\Ecommerce\Repositories
+ */
+class UserRepository extends RepositoryBase
+{
+    use UseFormRequestQueryBuilder;
+
+    /**
+     * RefundRepository constructor.
+     *
+     * @param EcommerceEntityManager $em
+     */
+    public function __construct(EcommerceEntityManager $em)
+    {
+        parent::__construct($em, $em->getClassMetadata(User::class));
+    }
+
+    /**
+     * @param Request $request
+     *
+     * @return ResultsQueryBuilderComposite
+     */
+    public function indexByRequest(Request $request): ResultsQueryBuilderComposite
+    {
+        $alias = 'u';
+
+        $qb = $this->createQueryBuilder($alias);
+
+        $qb->paginateByRequest($request)
+            ->orderByRequest($request, $alias)
+            ->select($alias);
+
+        if ($request->has('term')) {
+            $qb->andWhere(
+                    $qb->expr()
+                        ->like($alias . '.email', ':term')
+                )
+                ->setParameter('term', '%' . $request->get('term') . '%');
+        }
+
+        $results =
+            $qb->getQuery()
+                ->getResult();
+
+        return new ResultsQueryBuilderComposite($results, $qb);
+    }
+}


### PR DESCRIPTION
This adds a couple changes to ecommerce to provide data or functionality that I needed in the Shopify sync commands for customers and orders:

- OrderItem: I added the relationship to access its OrderItemFulfillments (which already had the inverse defined in OrderItemFulfillment), so I could get the fulfillments to build them up in Shopify
- OrderItemRepository: I added a query to get the Order Item by its shopify_id, so I could retrieve our Order Item corresponding to a fulfillment's line item
- UserRepository: I copied the CustomerRepository and updated it to provide a way to access the ecommerce User entity in the same was as the Customer entity. I needed this to get our Users and Customers that have the same email address, to build up one Customer in Shopify. These are also used to get their Addresses, to compile a complete list of unique addresses for the person.
- User: similar to the notes for UserRepository, I needed access to the attributes used to send the data to Shopify